### PR TITLE
Added support for 256. Changed README.md to reflect correct  meta mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Each buoy can be associated with a sound. As the buoy gets lifted up and down by
 
 **Short press** any grid key to toggle whats there - buoy vs piling vs nothing. If a buoy has never been edited on that key, then you'll just be toggling between piling and nothing.
 
-**Press all four keys on the corners** to get to meta mode. This is where you can do more setup type things that you probably don't want to use while performing but will need to do from time to time, like load a folder of samples.
+**Press all four keys on the corners of a 128** to get to meta mode. On Zero/256 the keys are the same as on a One/128. This is where you can do more setup type things that you probably don't want to use while performing but will need to do from time to time, like load a folder of samples.
 
 ### Arc
 The experience of using an arc definitely enhances buoys, however all the parameters you can access using arc can also be accessed in the parameters page and/or be mapped to an external midi controller (ideally one with knobs/encoders), so if you don't have one you are still gonna be just fine. The lighting displays on the arc are designed for horizontal use by default but can be switched to vertical by an option on the parameters page.

--- a/buoys.lua
+++ b/buoys.lua
@@ -2652,16 +2652,14 @@ function redraw_grid_main_view()
 end
 
 function fresh_grid(b)
-  return {
-    {b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b},
-    {b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b},
-    {b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b},
-    {b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b},
-    {b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b},
-    {b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b},
-    {b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b},
-    {b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b},
-  }
+  local gr = {}
+  for i = 1, g.rows do
+    gr[i] = {}
+    for j = 1, g.cols do
+      gr[i][j] = b
+    end
+  end
+  return gr
 end
 
 -- probability a fair coin flip is heads


### PR DESCRIPTION
Hi,

with the release of zero, I gave an attempt for 256 support. The biggest issue was fresh_grid, which generates a static table. I changed this to a table pulling from grid size.

Another small maybe-issue is Meta mode (line 106). Using the corners of the 16x16 grid is troublesome, so I left it as it is, but updated the readme a bit.